### PR TITLE
Add Rayman M/Arena Controls Configuration

### DIFF
--- a/GameConfigurations/Donald Duck - Quack Attack/Xidi.ini
+++ b/GameConfigurations/Donald Duck - Quack Attack/Xidi.ini
@@ -1,0 +1,36 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Donald Duck: Quack Attack / Donald Duck: Goin' Quackers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Xidi Version:     4.0.0
+; Xidi Form:        DInput
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Authors:          ICUP321
+; Last Modified:    02/05/2022
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+[Mapper]
+Type.1          = DonaldDuck
+
+
+[CustomMapper:DonaldDuck]
+
+; Directions
+StickLeftX      = Axis(X)
+StickLeftY      = Axis(Y)
+DpadUp          = Keyboard(Up)
+DpadDown        = Keyboard(Down)
+DpadLeft        = Keyboard(Left)
+DpadRight       = Keyboard(Right)
+
+; Jump / accept menu selection
+ButtonA         = Button(2)
+
+; Fire / cancel menu selection
+ButtonX         = Button(1)
+
+; View on-screen information
+ButtonB         = Keyboard(9)
+
+; Enter the menu
+ButtonStart     = Keyboard(Esc)

--- a/GameConfigurations/Rayman 2 - The Great Escape/Xidi.ini
+++ b/GameConfigurations/Rayman 2 - The Great Escape/Xidi.ini
@@ -1,11 +1,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Rayman 2: The Great Escape
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Xidi Version:     3.0.0
+; Xidi Version:     4.0.0
 ; Xidi Form:        DInput
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Authors:          samuelgr
-; Last Modified:    10/25/2021
+; Authors:          samuelgr, ICUP321
+; Last Modified:    02/05/2022
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -26,8 +26,8 @@ DpadRight       = Keyboard(Right)
 ; Camera controls
 ; Directions on right stick horizontal and both triggers, RS moves camera behind Rayman
 StickRightX     = Split( Button(3), Button(4) )
-TriggerLT       = Button(4)
-TriggerRT       = Button(3)
+ButtonLB        = Button(4)
+ButtonRB        = Button(3)
 ButtonRS        = Keyboard(End)
 
 ; Fire / accept menu selection
@@ -37,8 +37,8 @@ ButtonX         = Button(1)
 ButtonA         = Button(2)
 
 ; Strafe / dive underwater
-ButtonLB        = Button(5)
-ButtonRB        = Button(5)
+TriggerLT       = Button(5)
+TriggerRT       = Button(5)
 
 ; View on-screen information
 ButtonB         = Button(6)

--- a/GameConfigurations/Rayman M/Xidi.ini
+++ b/GameConfigurations/Rayman M/Xidi.ini
@@ -1,0 +1,58 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Rayman M / Rayman Arena
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Xidi Version:     4.0.0
+; Xidi Form:        DInput8
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Authors:          ICUP321
+; Last Modified:    2/3/2022
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+[Mapper]
+Type            = RaymanM
+
+
+[CustomMapper:RaymanM]
+; Default controls are optimized for Arena's Battle Mode, remap using game's control configuration menu for Race Mode
+
+; Directions and menu cursor movement
+; Both can be controlled via the left stick and the d-pad
+StickLeftX      = Compound(    Axis(X),    Split( Button(14), Button(16) )    )
+StickLeftY      = Compound(    Axis(Y),    Split( Button(15), Button(13) )    )
+DpadUp          = Compound(    Axis(Y, -), Button(13)    )
+DpadDown        = Compound(    Axis(Y, +), Button(15)    )
+DpadLeft        = Compound(    Axis(X, -), Button(16)    )
+DpadRight       = Compound(    Axis(X, +), Button(14)    )
+
+; Camera controls
+StickRightX     = Axis(RotZ)
+StickRightY     = Axis(Z)
+
+; Jump
+ButtonA         = Button(2)
+
+; Shoot / Fire
+ButtonX         = Button(1)
+
+; Optimisation / Realign Camera
+ButtonY         = Button(7)
+
+; Strafe-Lock
+TriggerLT       = Button(3)
+TriggerRT       = Button(3)
+
+; Discharge Item
+ButtonB         = Button(4)
+
+; Display / Toggle Radar
+ButtonBack      = Button(8)
+
+; Pause
+ButtonStart     = Button(9)
+
+; Camera left
+ButtonLB        = Button(5)
+
+; Camera right
+ButtonRB        = Button(6)

--- a/GameConfigurations/Rayman M/Xidi.ini
+++ b/GameConfigurations/Rayman M/Xidi.ini
@@ -5,7 +5,7 @@
 ; Xidi Form:        DInput8
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Authors:          ICUP321
-; Last Modified:    2/3/2022
+; Last Modified:    2/4/2022
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -14,7 +14,6 @@ Type            = RaymanM
 
 
 [CustomMapper:RaymanM]
-; Default controls are optimized for Arena's Battle Mode, remap using game's control configuration menu for Race Mode
 
 ; Directions and menu cursor movement
 ; Both can be controlled via the left stick and the d-pad
@@ -29,24 +28,24 @@ DpadRight       = Compound(    Axis(X, +), Button(14)    )
 StickRightX     = Axis(RotZ)
 StickRightY     = Axis(Z)
 
-; Jump
-ButtonA         = Button(2)
+; Jump / accept menu selection
+ButtonA         = Button(3)
 
 ; Shoot / Fire
-ButtonX         = Button(1)
+ButtonX         = Button(2)
+
+; Discharge Item / cancel menu selection
+ButtonB         = Button(1)
 
 ; Optimisation / Realign Camera
 ButtonY         = Button(7)
 
 ; Strafe-Lock
-TriggerLT       = Button(3)
-TriggerRT       = Button(3)
-
-; Discharge Item
-ButtonB         = Button(4)
+TriggerLT       = Button(8)
+TriggerRT       = Button(8)
 
 ; Display / Toggle Radar
-ButtonBack      = Button(8)
+ButtonBack      = Button(4)
 
 ; Pause
 ButtonStart     = Button(9)

--- a/GameConfigurations/Tonic Trouble/Xidi.ini
+++ b/GameConfigurations/Tonic Trouble/Xidi.ini
@@ -1,0 +1,57 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Tonic Trouble
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Xidi Version:     4.0.0
+; Xidi Form:        DInput
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Authors:          ICUP321
+; Last Modified:    02/05/2022
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+[Mapper]
+Type.1          = TonicTrouble
+
+
+[CustomMapper:TonicTrouble]
+
+; Directions
+StickLeftX      = Axis(X)
+StickLeftY      = Axis(Y)
+DpadUp          = Keyboard(Up)
+DpadDown        = Keyboard(Down)
+DpadLeft        = Keyboard(Left)
+DpadRight       = Keyboard(Right)
+
+; Jump / accept menu selection
+ButtonA         = Button(1)
+
+; Side Step
+TriggerLT       = Button(6)
+TriggerRT       = Button(6)
+
+; Action / cancel menu selection
+ButtonB         = Button(2)
+
+; Shoot 
+ButtonX         = Button(3)
+
+; Look
+ButtonY         = Button(4)
+
+; Camera Angle
+; Directions on right stick horizontal, RS toggles the camera angle
+ButtonRS        = Button(5)
+StickRightX     = Split( Keyboard(Numpad4), Keyboard(Numpad6) )
+
+; Toggle debug console
+ButtonLB        = Keyboard(F4)
+
+; Toggle on-screen information
+ButtonRB        = Keyboard(F9)
+
+; Pause
+ButtonStart     = Keyboard(Esc)
+
+; View game information
+ButtonBack      = Keyboard(F1)


### PR DESCRIPTION
Saw a few control configurations for Rayman games, couldn't help but notice Rayman M/Arena wasn't here, so I thought I'd make one. This game is kind of a mess when it comes to mapping button inputs, so I tried my best. I might make a few more control presets for other Ubisoft games in the future depending on how compatible this program is with them.