### PR TITLE
Added config for Looney Tunes: Sheep Raider

### DIFF
--- a/GameConfigurations/Looney Tunes - Sheep Raider/Xidi.ini
+++ b/GameConfigurations/Looney Tunes - Sheep Raider/Xidi.ini
@@ -1,0 +1,57 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Looney Tunes: Sheep Raider / Sheep, Dog, 'n' Wolf
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Xidi Version:     4.1.1
+; Xidi Form:        DInput8
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Authors:          JeffRuLz
+; Last Modified:    02/16/2023
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+[Mapper]
+Type.1          = SheepRaider
+
+
+[CustomMapper:SheepRaider]
+
+; Directions
+StickLeftX      = Axis(X)
+StickLeftY      = Axis(Y)
+DpadUp          = Axis(Y,-)
+DpadDown        = Axis(Y,+)
+DpadLeft        = Axis(X,-)
+DpadRight       = Axis(X,+)
+
+; Action
+ButtonA         = Button(1)
+
+; Jump
+ButtonX			= Button(4)
+
+; Wolf's Eye View
+ButtonY			= Button(5)
+
+; Run
+ButtonB			= Button(2)
+
+; Quick Inventory
+ButtonLB		= Button(7)
+
+; Walk Steathily
+ButtonRB		= Button(8)
+
+; Rotate Cam Left
+TriggerLT		= Button(6)
+
+; Rotate Cam Right
+TriggerRT		= Button(3)
+
+; View Map
+ButtonBack		= Button(9)
+
+; Pause Menu
+ButtonStart 	= Keyboard(Esc)
+
+; Right Stick Camera
+StickRightX     = Split( Button(3), Button(6) )


### PR DESCRIPTION
I made a config file for Looney Tunes: Sheep Raider / Sheep, Dog 'n' Wolf. 
It matches the PS1 controller layout with the default in-game button config.