### PR TITLE
added Garfield (2004)

### DIFF
--- a/GameConfigurations/Garfield (2004)/Xidi.ini
+++ b/GameConfigurations/Garfield (2004)/Xidi.ini
@@ -1,0 +1,27 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Garfield (2004)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Xidi Version:     4.2.0
+; Xidi Form:        dinput8
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Authors:          evanclue
+; Last Modified:    2023-12-14
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[Mapper]
+
+Type = Garfield
+
+[CustomMapper:Garfield]
+Template = StandardGamepad
+
+ButtonA = Button(3)
+ButtonB = Button(2)
+ButtonX = Button(4)
+ButtonY = Button(1)
+
+ButtonLB = Button(7)
+ButtonRB = Button(8)
+
+ButtonStart = Button(12)
+ButtonBack = Button(9)


### PR DESCRIPTION
Garfield (2004) is one of those unfortunate cases where the game came out right before Xinput, and requires an exceptionally niche Dinput controller that has two control sticks. When adding Xidi and this config file, a standard Xbox One controller will work instantly with no in-game configuration required.